### PR TITLE
removed the installation of the aside

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,12 @@ setup(
             'acid_parent = acid:AcidParentBlock',
         ],
         'xblock_asides.v1': [
-            'acid_aside = acid:AcidAside',
+
+            # Asides aren't ready yet, so we'll disable
+            # this for now.  When we get back to working on asides, we'll come
+            # up with a more sophisticated mechanism to enable this for the
+            # developers that want to see it.
+            # 'acid_aside = acid:AcidAside',
         ]
     },
     package_data=package_data("acid", ["static", "public"]),


### PR DESCRIPTION
Removing the installation of the Acid Aside because Asides have not been fully implemented yet. The inclusion of the aside makes it difficult to use the Acid Block in things like the XBlock-SDK. See [this pull request](https://github.com/edx/xblock-sdk/pull/91) for an in-depth discussion of the difficulties. 

As it stands, it seems like there is no specification or reference implementation for Aside functionality. Therefore, including a test for Asides might be a little premature. 