### PR TITLE
INCR-80: Run python-modernize on edx/acid-block

### DIFF
--- a/acid/acid.py
+++ b/acid/acid.py
@@ -1,5 +1,6 @@
 """An XBlock checking container/block relationships for correctness."""
 
+from __future__ import absolute_import
 import logging
 import pkg_resources
 import random
@@ -10,6 +11,7 @@ from mako.lookup import TemplateLookup
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import Scope, Dict
 from xblock.fragment import Fragment
+import six
 
 
 def generate_fields(cls):
@@ -110,7 +112,7 @@ class AcidSharedMixin(object):
 
         # Retrieve the field named for the scope (whose value is a dictionary)
         # and add an entry for this block's usage_id, set to `new_value`.
-        getattr(self, scope)[unicode(self.scope_ids.usage_id)] = new_value
+        getattr(self, scope)[six.text_type(self.scope_ids.usage_id)] = new_value
 
         query = 'QUERY={}&SCOPE={}'.format(new_value, scope)
         suffix = 'SUFFIX{}'.format(new_value)
@@ -142,7 +144,7 @@ class AcidSharedMixin(object):
         if 'QUERY' not in request.GET:
             return FailureResponse("QUERY is missing from query parameters")
 
-        stored_value = getattr(self, scope).get(unicode(self.scope_ids.usage_id))
+        stored_value = getattr(self, scope).get(six.text_type(self.scope_ids.usage_id))
         query_value = int(request.GET['QUERY'])
 
         if stored_value != query_value:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Set up for XBlock acid block."""
 
+from __future__ import absolute_import
 import os
 
 from setuptools import setup


### PR DESCRIPTION
Fixes INCR-80 https://openedx.atlassian.net/browse/INCR-80

$ __python-modernize -w .__

Ready to be reviewed.

Fixes all issues raised by [flake8](http://flake8.pycqa.org) testing of https://github.com/edx/acid-block on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./acid/acid.py:113:30: F821 undefined name 'unicode'
        getattr(self, scope)[unicode(self.scope_ids.usage_id)] = new_value
                             ^
./acid/acid.py:145:49: F821 undefined name 'unicode'
        stored_value = getattr(self, scope).get(unicode(self.scope_ids.usage_id))
                                                ^
2     F821 undefined name 'unicode'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
