### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with 
 	pip install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,35 +6,33 @@
 #
 appdirs==1.4.4
     # via fs
-fs==2.4.14
+fs==2.4.16
     # via xblock
 lazy==1.4
     # via -r requirements/base.in
-lxml==4.6.4
+lxml==4.9.0
     # via xblock
-mako==1.1.6
+mako==1.2.0
     # via -r requirements/base.in
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   mako
     #   xblock
 python-dateutil==2.8.2
     # via xblock
-pytz==2021.3
-    # via
-    #   fs
-    #   xblock
+pytz==2022.1
+    # via xblock
 pyyaml==6.0
     # via xblock
 six==1.16.0
     # via
     #   fs
     #   python-dateutil
-web-fragments==1.1.0
+web-fragments==2.0.0
     # via xblock
 webob==1.8.7
     # via xblock
-xblock==1.5.1
+xblock==1.6.1
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -13,8 +13,13 @@
 
 
 # using LTS django version
-Django<3.3
+Django<4.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,3 +1,4 @@
+-c constraints.txt
 # Core dependencies for installing other packages
 
 pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.37.0
+wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==22.1.2
     # via -r requirements/pip.in
-setuptools==59.5.0
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.2
     # via -r requirements/pip_tools.in
-tomli==1.2.2
+tomli==2.0.1
     # via pep517
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,48 +4,50 @@
 #
 #    make upgrade
 #
-astroid==2.9.0
+astroid==2.11.6
     # via
     #   pylint
     #   pylint-celery
-attrs==21.2.0
+attrs==21.4.0
     # via pytest
-click==8.0.3
+click==8.1.3
     # via
     #   click-log
     #   code-annotations
     #   edx-lint
-click-log==0.3.2
+click-log==0.4.0
     # via edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==6.2
+coverage[toml]==6.4.1
     # via pytest-cov
-edx-lint==5.2.1
+dill==0.3.5.1
+    # via pylint
+edx-lint==5.2.4
     # via -r requirements/test.in
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-jinja2==3.0.3
+jinja2==3.1.2
     # via code-annotations
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 packaging==21.3
     # via pytest
-pbr==5.8.0
+pbr==5.9.0
     # via stevedore
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pylint==2.12.2
+pylint==2.14.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -53,19 +55,19 @@ pylint==2.12.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.4.4
+pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.6
+pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.6
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/test.in
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via code-annotations
 pyyaml==6.0
     # via code-annotations
@@ -75,17 +77,18 @@ stevedore==3.5.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-toml==0.10.2
+tomli==2.0.1
     # via
+    #   coverage
     #   pylint
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.1
+tomlkit==0.11.0
+    # via pylint
+typing-extensions==4.2.0
     # via
     #   astroid
     #   pylint
-wrapt==1.13.3
+wrapt==1.14.1
     # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3446